### PR TITLE
Add custom delimiter support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -79,3 +79,4 @@ results
 npm-debug.log
 node_modules
 .coverage
+.nyc_output

--- a/README.md
+++ b/README.md
@@ -12,10 +12,18 @@ Object flattener helper library. Convert (nested) objects to and from flat objec
 `flatten(source,[delimeter='.'])`
 
 Transform any deep nested object in a flat object of keypath values.
+You can specify a custom path delimiter (defaults to `.`)
 
 ```js
-Flattener.flatten({user: { name: 'peperone' }})
+Flattener.flatten({user: { name: 'peperone' }});
 {'user.name': 'peperone'}
+```
+
+Custom delimiter:
+
+```js
+Flattener.flatten({user: { name: 'peperone' }}, '/');
+{'user/name': 'peperone'}
 ```
 
 ### unflatten
@@ -25,7 +33,14 @@ Flattener.flatten({user: { name: 'peperone' }})
 Transform a flattened object into a regular object.
 
 ```js
-Flattener.flatten({'user.name': 'peperone'})
+Flattener.flatten({'user.name': 'peperone'});
+{user: { name: 'peperone' }}
+```
+
+Custom delimiter:
+
+```js
+Flattener.flatten({'user/name': 'peperone'}, '/');
 {user: { name: 'peperone' }}
 ```
 

--- a/README.md
+++ b/README.md
@@ -2,15 +2,104 @@
 
 [![Build Status](https://secure.travis-ci.org/goliatone/flattener.png)](http://travis-ci.org/goliatone/flattener)
 
-Object flattener helper library
+Object flattener helper library. Convert (nested) objects to and from flat objects of keypath values.
+
+
+## Documentation
+
+### flatten
+
+`flatten(source,[delimeter='.'])`
+
+Transform any deep nested object in a flat object of keypath values.
+
+```js
+Flattener.flatten({user: { name: 'peperone' }})
+{'user.name': 'peperone'}
+```
+
+### unflatten
+
+`unflatten(flatObject,[delimeter='.'])`
+
+Transform a flattened object into a regular object.
+
+```js
+Flattener.flatten({'user.name': 'peperone'})
+{user: { name: 'peperone' }}
+```
+
+### glob
+
+`glob(flatObject,regexp)`
+
+Iterate over all keys and return the ones matching a given regexp.
+
+
+## Examples
+
+The following is an example of flattening a user object:
+
+```js
+let user = {
+  name: { title: 'mr', first: 'brad', last: 'gibson' },
+  location: {
+    street: '9278 new road',
+    city: 'kilcoole',
+    state: 'waterford',
+    postcode: '93027',
+    coordinates: { latitude: '20.9267', longitude: '-7.9310' },
+    timezone: { offset: '-3:30', description: 'Newfoundland' }
+  },
+  email: 'brad.gibson@example.com',
+  handles: [
+    { site: 'twitter', handle: 'mr.brad' },
+    { site: 'github', handle: 'bradC0d3z' }
+  ]
+};
+
+let flatUser = Flattener.flatten(user);
+console.log(flatUser);
+```
+
+The output in the console would show something similar to the following:
+
+```js
+{
+  'name.title': 'mr',
+  'name.first': 'brad',
+  'name.last': 'gibson',
+  'location.street': '9278 new road',
+  'location.city': 'kilcoole',
+  'location.state': 'waterford',
+  'location.postcode': '93027',
+  'location.coordinates.latitude': '20.9267',
+  'location.coordinates.longitude': '-7.9310',
+  'location.timezone.offset': '-3:30',
+  'location.timezone.description': 'Newfoundland',
+  email: 'brad.gibson@example.com',
+  'handles.0.site': 'twitter',
+  'handles.0.handle': 'mr.brad',
+  'handles.1.site': 'github',
+  'handles.1.handle': 'bradC0d3z'
+}
+```
+
+You can go back to a regular object:
+
+```js
+let obj = Flattener.unflatten(flatUser);
+```
 
 ## Getting Started
+
 Download the [production version][min] or the [development version][max].
 
 [min]: https://raw.github.com/goliatone/gflattener/master/dist/flattener.min.js
 [max]: https://raw.github.com/goliatone/gflattener/master/dist/flattener.js
 
 ## Development
+
 `npm install && bower install`
 
 If you need to `sudo` the `npm` command, you can try to:
@@ -30,6 +119,7 @@ If you bump versions, remember to update:
 
 
 ## Bower
+
 >Bower is a package manager for the web. It offers a generic, unopinionated solution to the problem of front-end package management, while exposing the package dependency model via an API that can be consumed by a more opinionated build stack. There are no system wide dependencies, no dependencies are shared between different apps, and the dependency tree is flat.
 
 To register flattener in the [bower](http://bower.io/) [registry](http://sindresorhus.com/bower-components/):
@@ -45,14 +135,8 @@ And push it:
 
 
 ## Travis
+
 In order to enable Travis for this specific project, you need to do so on your Travi's [profile](https://travis-ci.org/profile). Look for the entry `goliatone/flattener`, activate, and sync.
-
-
-## Documentation
-_(Coming soon)_
-
-## Examples
-_(Coming soon)_
 
 ## Release History
 _(Nothing yet)_

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "scripts": {
     "test": "bogota",
     "dtest": "watch bogota test/",
-    "coverare": "nyc npm run test"
+    "coverage": "nyc npm run test"
   },
   "main": "index.js",
   "repository": {

--- a/src/flattener.js
+++ b/src/flattener.js
@@ -65,16 +65,17 @@
      * @param  {Object} src    Object to be serialized
      * @return {Object}        Serialized object.
      */
-    Flattener.flatten = function flatten(src, /*private*/ prop, output) {
+    Flattener.flatten = function flatten(src, delimiter, /*private*/ prop, output) {
         prop || (prop = '');
         output || (output = {});
+        delimiter || (delimiter = '.');
 
         var isEmpty = false;
 
         if (Object(src) !== src) output[prop] = src;
         else if (Array.isArray(src)) {
             for (var i = 0, l = src.length; i < l; i++) {
-                flatten(src[i], prop ? prop + '.' + i : '' + i, output);
+                flatten(src[i], delimiter, prop ? prop + delimiter + i : '' + i, output);
             }
             if (l === 0) output[prop] = [];
         } else {
@@ -82,7 +83,7 @@
             for (var p in src) {
                 isEmpty = false;
                 if (src !== src[p]) {
-                    flatten(src[p], prop ? prop + '.' + p : p, output);
+                    flatten(src[p], delimiter, prop ? prop + delimiter + p : p, output);
                 }
             }
             if (isEmpty) output[prop] = {};
@@ -98,8 +99,9 @@
      * @param  {Object} src Map to be unmapped
      * @return {Object}
      */
-    Flattener.unflatten = function unflatten(src) {
+    Flattener.unflatten = function unflatten(src, delimiter) {
         if (Object(src) !== src || Array.isArray(src)) return src;
+        delimiter || (delimiter = '.');
 
         var result = {},
             cur, prop, idx, last, temp;
@@ -107,7 +109,7 @@
             cur = result, prop = '__ROOT__', last = 0;
 
             do {
-                idx = p.indexOf('.', last);
+                idx = p.indexOf(delimiter, last);
                 temp = p.substring(last, idx !== -1 ? idx : undefined);
                 cur = cur[prop] || (cur[prop] = (!isNaN(parseInt(temp)) ? [] : {}));
                 prop = temp;
@@ -143,6 +145,7 @@
         Object.keys(map).forEach(function(key) {
             if (regexp.exec(key)) out[key] = map[key];
         });
+
         return out;
     };
 

--- a/test/flattener_test.js
+++ b/test/flattener_test.js
@@ -35,6 +35,19 @@ test('should flatten objects', t => {
     t.end();
 });
 
+test('should flatten array of objects', t => {
+    let src = {
+        metadata: { ruckus: { id: 23 }, items: [{ id: 1 }] },
+    };
+
+    let out = Flattener.flatten(src);
+
+    let expected = Flattener.unflatten(out);
+
+    t.deepEquals(src, expected);
+    t.end();
+});
+
 
 test('should unflatten objects', t => {
     let src = {
@@ -93,5 +106,62 @@ test('invalidRegExpObj helper', t => {
 
     out = Flattener.invalidRegExpObj(23);
     t.notOk(out);
+    t.end();
+});
+
+
+test('should flatten objects using custom delimiter', t => {
+    let expected = {
+        'prop1/inside1/value1': 'value1',
+        'prop1/array1/0': 'arr1',
+        'prop1/array1/1': 'arr2',
+        'prop2/inside2/value2': 'value2'
+    };
+
+    let src = {
+        prop1: {
+            inside1: {
+                value1: 'value1'
+            },
+            array1: ['arr1', 'arr2']
+        },
+        prop2: {
+            inside2: {
+                value2: 'value2'
+            }
+        }
+    };
+
+    let out = Flattener.flatten(src, '/');
+
+    t.deepEquals(out, expected);
+    t.end();
+});
+
+test('should unflatten objects using custom delimiter', t => {
+    let src = {
+        'prop1/inside1/value1': 'value1',
+        'prop1/array1/0': 'arr1',
+        'prop1/array1/1': 'arr2',
+        'prop2/inside2/value2': 'value2'
+    };
+
+    let expected = {
+        prop1: {
+            inside1: {
+                value1: 'value1'
+            },
+            array1: ['arr1', 'arr2']
+        },
+        prop2: {
+            inside2: {
+                value2: 'value2'
+            }
+        }
+    };
+
+    let out = Flattener.unflatten(src, '/');
+
+    t.deepEquals(out, expected);
     t.end();
 });


### PR DESCRIPTION
This closes #3 by adding a delimiter option to `flatten` and `unflatten` methods.